### PR TITLE
fix: 商品テーブルの外部キー制約に使用するカラムのデータ型がユーザテーブルのデータ型と異なる

### DIFF
--- a/database/migrations/2024_03_04_060523_create_products_table.php
+++ b/database/migrations/2024_03_04_060523_create_products_table.php
@@ -15,10 +15,10 @@ return new class extends Migration
             $table->mediumIncrements('id');
             $table->string('name');
             $table->timestamps();
-            $table->foreignId('user_id')
-                ->constrained()
-                ->cascadeOnUpdate()
-                ->cascadeOnDelete();
+            $table->unsignedMediumInteger('user_id');
+            $table->foreign('user_id')
+            ->references('id')
+            ->on('users');
         });
     }
 


### PR DESCRIPTION
【原因】
商品テーブルとユーザテーブルの外部キー制約に関連するカラムのデータ型が異なる。
これにより外部キー制約のエラーが発生する。

・商品テーブル(子テーブル)
user_idカラムのデータ型：unsigned bigint型

・ユーザテーブル(親テーブル)
idカラムのデータ型：unsigned mediumint型

【修正内容】
商品テーブルのuser_idカラムをunsigned mediumint型に修正する。

【確認作業】
phpMyAdminで商品テーブルのuser_idカラムがunsigned mediumint型になっていることを確認する。

#7