### PR TITLE
add: クチコミテーブルのuser_idカラムとproduct_idカラムにユニークキー制約を追加

### DIFF
--- a/database/migrations/2024_03_06_003155_create_reviews_table.php
+++ b/database/migrations/2024_03_06_003155_create_reviews_table.php
@@ -27,6 +27,7 @@ return new class extends Migration
                 ->on('users')
                 ->cascadeOnUpdate()
                 ->cascadeOnDelete();
+            $table->unique(['product_id', 'user_id']);
         });
     }
 


### PR DESCRIPTION
保存するデータの重複を防ぐため。