### PR TITLE
add: Productモデルに関するポリシー(認可ロジック)を追加

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -13,6 +13,18 @@ use App\Models\Product;
 class ProductController extends Controller
 {
     /**
+     * 初期化
+     * 
+     * ポリシーで本コントローラーのメソッドの実行を制限する
+     * 
+     * @access public
+     */
+    public function __construct()
+    {
+        $this->authorizeResource(Product::class, 'product');
+    }
+
+    /**
      * Display a listing of the resource.
      * 
      * @access public

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -28,4 +28,16 @@ class Product extends Model
             ->orderBy('pivot_id', 'desc')
             ->withTimestamps();
     }
+
+    /**
+     * 同じユーザIDか判定する
+     *
+     * @access public
+     * @param  int $user_id
+     * @return bool
+     */
+    public function isSameUserId(int $user_id): bool
+    {
+        return $this->user_id === $user_id;
+    }
 }

--- a/app/Policies/ProductPolicy.php
+++ b/app/Policies/ProductPolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class ProductPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     * 
+     * @access public
+     * @param  \App\Models\User $user
+     * @return bool
+     */
+    public function viewAny(?User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     * 
+     * @access public
+     * @param  \App\Models\User $user
+     * @param  \App\Models\Product $product
+     * @return bool
+     */
+    public function view(?User $user, Product $product): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     * 
+     * @access public
+     * @param  \App\Models\User $user
+     * @return bool
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     * 
+     * @access public
+     * @param  \App\Models\User $user
+     * @param  \App\Models\Product $product
+     * @return bool
+     */
+    public function update(User $user, Product $product): bool
+    {
+        return $product->isSameUserId($user->id);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     * 
+     * @access public
+     * @param  \App\Models\User $user
+     * @param  \App\Models\Product $product
+     * @return bool
+     */
+    public function delete(User $user, Product $product): bool
+    {
+        return $product->isSameUserId($user->id);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,7 +5,9 @@ namespace App\Providers;
 // use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use App\Models\Review;
+use App\Models\Product;
 use App\Policies\ReviewPolicy;
+use App\Policies\ProductPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -16,6 +18,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Review::class => ReviewPolicy::class,
+        Product::class => ProductPolicy::class,
     ];
 
     /**


### PR DESCRIPTION
Productテーブルに対する操作に制限を設けていないため。

【追加による変更点】
・認証済みユーザは、自らが投稿した商品を編集、更新することができる。
・認証済みユーザは、自らが投稿した商品を削除することができる。