### PR TITLE
update: 商品画像ファイルの削除処理をProductImageクラスに委譲

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -100,7 +100,7 @@ class Product extends Model
     public function deleteProductImagesInStorage(array $uploaded_files): void
     {
         foreach (array_keys($uploaded_files) as $key) {
-            StorageService::deleteFile(StorageService::PRODUCT_DIRECTORY, $this->productImages[$key]->name);
+            $this->productImages[$key]->deleteProductImagesInStorage();
         }
     }
 

--- a/app/Models/ProductImage.php
+++ b/app/Models/ProductImage.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Services\StorageService;
 
 class ProductImage extends Model
 {
@@ -12,4 +13,15 @@ class ProductImage extends Model
     protected $fillable = [
         'name',
     ];
+
+    /**
+     * ストレージから商品画像ファイルを削除する
+     *
+     * @access public
+     * @return void
+     */
+    public function deleteProductImagesInStorage(): void
+    {
+        StorageService::deleteFile(StorageService::PRODUCT_DIRECTORY, $this->name);
+    }
 }


### PR DESCRIPTION
MVCモデルのプログラム実装に従うため。

商品画像ファイルを削除する際に商品画像ファイル名が必要になる。
商品画像ファイル名を知っているのはProductImageクラスである。

そのため、商品画像ファイルの削除処理をProductImageクラスに委譲する。